### PR TITLE
add a final newline ie to MANFEST.MF

### DIFF
--- a/lmh/lib/io.py
+++ b/lmh/lib/io.py
@@ -177,7 +177,7 @@ def write_file(filename, text):
     if isinstance(text, basestring):
         text_file.write(text)
     else:
-        text_file.write("\n".join(text))
+        text_file.write("\n".join(text) + "\n")
     text_file.close()
 
     return True


### PR DESCRIPTION
this patch adds a final newline when (completely) rewriting `META-INF/MANIFEST.MF` with a new or modified `generated-branches:` line, when calling `lmh gbranch --init branch`.

I'm not sure which other files get a final newline now, but this should be the default.

Btw. `gbranch.py` inserts empty (and repeated) lines into .gitignore for multiple calls of `lmh gbranch --init branch`.
