### PR TITLE
assume a final newline in .gitignore

### DIFF
--- a/lmh/lib/repos/gbranch.py
+++ b/lmh/lib/repos/gbranch.py
@@ -157,7 +157,7 @@ class Generated:
 
         # and either add to it or create it.
         if os.path.isfile(gitignore_path):
-            write_file(gitignore_path, read_file(gitignore_path)+"\n"+gitignore_entry)
+            write_file(gitignore_path, read_file(gitignore_path)+gitignore_entry)
         else:
             write_file(gitignore_path, gitignore_entry)
 


### PR DESCRIPTION
when adding a new line to `.gitignore` we should assume it has already a final newline. (If not it must be fixed manually.)
