### PR TITLE
Dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+dist: trusty
+language: python
+ - "3.5"
+
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq cpanminus texlive-xetex
+
+script:
+ - export LMH_ROOT_DIR=`pwd`
+ - export PATH=`pwd`/bin:$PATH
+ - lmh setup --install LaTeXML LaTeXMLs sTeX

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: python
 
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq cpanminus texlive-xetex
+ - sudo apt-get install -qq cpanminus texlive-xetex libxml-libxslt-perl libparse-recdescent-perl
 
 script:
  - export LMH_ROOT_DIR=`pwd`

--- a/bin/lmh
+++ b/bin/lmh
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/lmh/data/aliases.json
+++ b/lmh/data/aliases.json
@@ -5,10 +5,10 @@
   "update": "pull",
   "selfupdate": "setup --update self",
 
-  "gen": "mmt rbuild",
-  "sms": "mmt rbuild sms",
-  "omdoc": "mmt rbuild latexml",
-  "pdf": "mmt rbuild pdflatex",
-  "alltex": "mmt rbuild alltex",
-  "allpdf": "mmt rbuild allpdf"
+  "gen": "mmt make",
+  "sms": "mmt make sms",
+  "omdoc": "mmt make latexml",
+  "pdf": "mmt make pdflatex",
+  "alltex": "mmt make alltex",
+  "allpdf": "mmt make allpdf"
 }


### PR DESCRIPTION
I've used the `dev` branch in my setup. Therefore I believe it is safe to merge this changes. Users should only be effected by the explicit change to python3. lmh uses now the new `make` instead of `rbuild` for MMT (therefore old versions of MMT would not work, but `lmh setup --update` will install the newest version).
